### PR TITLE
Feat: Snippet hashtag filtering

### DIFF
--- a/routes/snippets.js
+++ b/routes/snippets.js
@@ -21,12 +21,19 @@ router.get("/", async (req, res, next) => {
     const { language } = req.query;
     const snippetList = await Snippet.find({ language });
 
-    const result = {
-      result: MESSAGES.OK,
-      snippetList,
-    };
+    res.status(200).send({ result: OK , snippetList });
+  } catch (error) {
+    next(error);
+  }
+});
 
-    res.send(result);
+router.get("/", async (req, res, next) => {
+  try {
+    const { hashtag } = req.query;
+    const searched = await Hashtag.findOne({ name: hashtag });
+    const snippetList = searched.snippetList;
+
+    res.status(200).send({ result: OK , snippetList });
   } catch (error) {
     next(error);
   }

--- a/routes/snippets.js
+++ b/routes/snippets.js
@@ -17,8 +17,9 @@ const {
 } = require("../constants/messages");
 
 router.get("/", async (req, res, next) => {
+  const { language } = req.query;
+
   try {
-    const { language } = req.query;
     const snippetList = await Snippet.find({ language });
 
     res.status(200).send({ result: OK , snippetList });
@@ -28,8 +29,9 @@ router.get("/", async (req, res, next) => {
 });
 
 router.get("/", async (req, res, next) => {
+  const { hashtag } = req.query;
+
   try {
-    const { hashtag } = req.query;
     const searched = await Hashtag.findOne({ name: hashtag });
     const snippetList = searched.snippetList;
 

--- a/routes/snippets.js
+++ b/routes/snippets.js
@@ -17,25 +17,23 @@ const {
 } = require("../constants/messages");
 
 router.get("/", async (req, res, next) => {
-  const { language } = req.query;
+  const { language, hashtag } = req.query;
 
   try {
-    const snippetList = await Snippet.find({ language });
+    if (language) {
+      const snippetList = await Snippet.find({ language });
 
-    res.status(200).send({ result: OK , snippetList });
-  } catch (error) {
-    next(error);
-  }
-});
+      res.status(200).send({ result: OK , snippetList });
 
-router.get("/", async (req, res, next) => {
-  const { hashtag } = req.query;
+      return;
+    }
 
-  try {
-    const searched = await Hashtag.findOne({ name: hashtag });
-    const snippetList = searched.snippetList;
+    if (hashtag) {
+      const searched = await Hashtag.findOne({ name: hashtag });
+      const snippetList = searched.snippetList;
 
-    res.status(200).send({ result: OK , snippetList });
+      res.status(200).send({ result: OK , snippetList });
+    }
   } catch (error) {
     next(error);
   }


### PR DESCRIPTION
## 해시태그로 스니펫 리스트 필터링

### 특이사항
- language로 스니펫 리스트를 필터링하는 로직도 변경된 컨벤션에 맞게 수정했습니다.
- postman으로 확인한 결과, language 필터링 라우터와 hashtag 필터링 라우터가 동시에 존재하면 앞서 위치한 로직만 정상적으로 작동합니다. 경로가 동일한 탓으로 보이는데, 다음과 같이 작성하면 두 기능 모두 작동합니다. 혹은 다른 좋은 방법이 있는지 이야기 나눠보면 좋을 것 같습니다.

```
router.get("/", async (req, res, next) => {
  const { language, hashtag } = req.query;

  try {
    if (language) {
      const snippetList = await Snippet.find({ language });

      res.status(200).send({ result: OK , snippetList });

      return;
    }

    if (hashtag) {
      const searched = await Hashtag.findOne({ name: hashtag });
      const snippetList = searched.snippetList;

      res.status(200).send({ result: OK , snippetList });
    }
  } catch (error) {
    next(error);
  }
});
```